### PR TITLE
Android bluetooth permissions

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,4 +1,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="com.donkeylockkit">
-
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" />
+    <uses-permission android:name="android.permission.BLUETOOTH"
+                     android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"
+                     android:maxSdkVersion="30" />
 </manifest>


### PR DESCRIPTION
Hi, 
We would like our Android users to be prompted to enable bluetooth permissions when using our app. 
Looking at [expo's documentation](https://docs.expo.dev/guides/permissions/#android) it seems that it is the easiest if it is added in the library itself:

> Most permissions are added automatically by libraries that you use in your app either with [config plugins](https://docs.expo.dev/guides/config-plugins/) or with a package-level AndroidManifest.xml, so you won't often need to use android.permissions to add additional permissions.

We were a bit unsure about which permissions exactly are needed. Is BLUETOOTH_CONNECT needed as well? Do these permissions look correct for the use case?
